### PR TITLE
Improve performance by caching regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,3 @@
-var removeAccents = function(string) {
-	for( accented in characterMap ) {
-		string = string.replace( new RegExp(accented, "g"), characterMap[accented] );
-	}
-
-	return string;
-}
-
 var characterMap = {
 	"À": "A",
 	"Á": "A",
@@ -345,6 +337,28 @@ var characterMap = {
 	"ȑ": "r",
 	"Ȕ": "U",
 	"ȕ": "u",
+}
+
+var accentsRegex;
+
+function buildRegExp() {
+	var accentList = [];
+
+	for( accented in characterMap ) {
+		accentList.push(accented);
+	}
+
+	accentsRegex = new RegExp('(' + accentList.join('|') + ')', 'g');
+}
+
+buildRegExp();
+
+var removeAccents = function(string) {	
+	string = string.replace(accentsRegex, function(match) {
+		return characterMap[match];
+	})
+
+	return string;
 }
 
 module.exports = removeAccents;


### PR DESCRIPTION
This greatly improves performance, instead of creating 300 regex objects and running them on every single call, it builds the regex and caches it.

I had some pretty bad performance without it.

![image](https://cloud.githubusercontent.com/assets/697707/19770646/b4907e2c-9c68-11e6-9735-7d7b6db480f9.png)

PS: Could you also release to NPM after you approve this?

Thanks!
