### PR TITLE
Fix missing `var` keyword

### DIFF
--- a/index.js
+++ b/index.js
@@ -406,7 +406,7 @@ var accentsRegex;
 function buildRegExp() {
 	var accentList = [];
 
-	for( accented in characterMap ) {
+	for(var accented in characterMap ) {
 		accentList.push(accented);
 	}
 


### PR DESCRIPTION
The missing `var` keyword would crash when in Chrome, with an error "accented" is not defined