### PR TITLE
Gitignore: Ignore lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+
+# Lock files
+package-lock.json
+yarn.lock


### PR DESCRIPTION
This adds `package-lock.json` and `yarn.lock` to the list of ignored files.