### PR TITLE
Remove Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: node_js
-node_js:
-  - "0.10"
-  - "0.11"
-  - "0.12"
-
-script: "npm test"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Removes the accents from a string, converting them to their corresponding non-ac
 npm install remove-accents
 ```
 
-[![Build Status](https://travis-ci.org/tyxla/remove-accents.svg)](https://travis-ci.org/tyxla/remove-accents)
 [![Unit tests](https://github.com/tyxla/remove-accents/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/tyxla/remove-accents/actions/workflows/unit-tests.yml)
 
 ## About


### PR DESCRIPTION
This PR removes the obsolete and unused Travis CI config. We're now using GitHub actions as our CI to run tests.