### PR TITLE
Replace `tape` with `jest`

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x, 16.x, 17.x, 18.x, 19.x]
+        node-version: [14.x, 15.x, 16.x, 17.x, 18.x, 19.x, 20.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	testEnvironment: 'node',
+	testMatch: [ '<rootDir>/test.js' ],
+};

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "main": "index.js",
   "dependencies": {},
   "devDependencies": {
-    "tape": "^4.2.2"
+    "jest": "^29.6.2"
   },
   "scripts": {
-    "test": "tape test.js"
+    "test": "jest -c=jest.config.js"
   },
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -1,56 +1,47 @@
-var tape = require('tape');
-var removeAccents = require('./');
+var removeAccents = require("./");
 
-tape('remove accents from string', function(t) {
-	var input = 'ÀÁÂÃÄÅẤẮÆẦẰẢẠẨẪẬÇḈÈÉÊËẾḖỀḔẺẼẸỂỄỆÌÍÎÏḮỈỊÐÑÒÓÔÕÖØỐṌṒỎỌỔỖỘỜỞỠỚỢÙÚÛÜỦỤỬỮỰÝàáâãäåấắæầằảạẩẫậçḉèéêëếḗềḕẻẽẹểễệìíîïḯỉịñòóôõöøốṍṓỏọổỗộờởỡớợùúûüủụửữựýÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģǴǵĤĥĦħĨĩĪīĬĭĮįİıĲĳĴĵĶķḰḱĹĺĻļĽľĿŀŁłḾḿŃńŅņŇňŉŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵẂẃŶŷŸŹźŻżŽžſƒƠơƯưǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜỨứṸṹǺǻǼǽǾǿðÞþṔṕṤṥX́x́ЃѓЌќA̋a̋E̋e̋I̋i̋ǸǹỒồṐṑỪừẀẁỲỳȀȁȄȅȈȉȌȍȐȑȔȕẲẴẶḜẳẵặḝC̆c̆ḪḫK̆k̆M̆m̆N̆n̆P̆p̆R̆r̆T̆t̆V̆v̆X̆x̆Y̆y̆ȂȆȊȎȃȇȋȏȒȓȖȗșțȘȚB̌b̌F̌f̌ǦǧȞȟJ̌ǰǨǩM̌m̌P̌p̌Q̌q̌ṦṧV̌v̌W̌w̌X̌x̌Y̌y̌A̧a̧B̧b̧ḐḑȨȩƐ̧ɛ̧ḨḩI̧i̧Ɨ̧ɨ̧M̧m̧O̧o̧Q̧q̧U̧u̧X̧x̧Z̧z';
+test("remove accents from string", function () {
+	var input =
+		"ÀÁÂÃÄÅẤẮÆẦẰẢẠẨẪẬÇḈÈÉÊËẾḖỀḔẺẼẸỂỄỆÌÍÎÏḮỈỊÐÑÒÓÔÕÖØỐṌṒỎỌỔỖỘỜỞỠỚỢÙÚÛÜỦỤỬỮỰÝàáâãäåấắæầằảạẩẫậçḉèéêëếḗềḕẻẽẹểễệìíîïḯỉịñòóôõöøốṍṓỏọổỗộờởỡớợùúûüủụửữựýÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģǴǵĤĥĦħĨĩĪīĬĭĮįİıĲĳĴĵĶķḰḱĹĺĻļĽľĿŀŁłḾḿŃńŅņŇňŉŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵẂẃŶŷŸŹźŻżŽžſƒƠơƯưǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜỨứṸṹǺǻǼǽǾǿðÞþṔṕṤṥX́x́ЃѓЌќA̋a̋E̋e̋I̋i̋ǸǹỒồṐṑỪừẀẁỲỳȀȁȄȅȈȉȌȍȐȑȔȕẲẴẶḜẳẵặḝC̆c̆ḪḫK̆k̆M̆m̆N̆n̆P̆p̆R̆r̆T̆t̆V̆v̆X̆x̆Y̆y̆ȂȆȊȎȃȇȋȏȒȓȖȗșțȘȚB̌b̌F̌f̌ǦǧȞȟJ̌ǰǨǩM̌m̌P̌p̌Q̌q̌ṦṧV̌v̌W̌w̌X̌x̌Y̌y̌A̧a̧B̧b̧ḐḑȨȩƐ̧ɛ̧ḨḩI̧i̧Ɨ̧ɨ̧M̧m̧O̧o̧Q̧q̧U̧u̧X̧x̧Z̧z";
 	var output = removeAccents(input);
-        var expected = 'AAAAAAAAAEAAAAAAACCEEEEEEEEEEEEEEIIIIIIIDNOOOOOOOOOOOOOOOOOOOUUUUUUUUUYaaaaaaaaaeaaaaaaacceeeeeeeeeeeeeeiiiiiiinooooooooooooooooooouuuuuuuuuyyAaAaAaCcCcCcCcDdDdEeEeEeEeEeGgGgGgGgGgHhHhIiIiIiIiIiIJijJjKkKkLlLlLlLlllMmNnNnNnnOoOoOoOEoeRrRrRrSsSsSsSsTtTtTtUuUuUuUuUuUuWwWwYyYZzZzZzsfOoUuAaIiOoUuUuUuUuUuUuUuAaAEaeOodTHthPpSsXxГгКкAaEeIiNnOoOoUuWwYyAaEeIiOoRrUuAAAEaaaeCcHhKkMmNnPpRrTtVvXxYyAEIOaeioRrUustSTBbFfGgHhJjKkMmPpQqSsVvWwXxYyAaBbDdEeEeHhIiIiMmOoQqUuXxZz';
+	var expected =
+		"AAAAAAAAAEAAAAAAACCEEEEEEEEEEEEEEIIIIIIIDNOOOOOOOOOOOOOOOOOOOUUUUUUUUUYaaaaaaaaaeaaaaaaacceeeeeeeeeeeeeeiiiiiiinooooooooooooooooooouuuuuuuuuyyAaAaAaCcCcCcCcDdDdEeEeEeEeEeGgGgGgGgGgHhHhIiIiIiIiIiIJijJjKkKkLlLlLlLlllMmNnNnNnnOoOoOoOEoeRrRrRrSsSsSsSsTtTtTtUuUuUuUuUuUuWwWwYyYZzZzZzsfOoUuAaIiOoUuUuUuUuUuUuUuAaAEaeOodTHthPpSsXxГгКкAaEeIiNnOoOoUuWwYyAaEeIiOoRrUuAAAEaaaeCcHhKkMmNnPpRrTtVvXxYyAEIOaeioRrUustSTBbFfGgHhJjKkMmPpQqSsVvWwXxYyAaBbDdEeEeHhIiIiMmOoQqUuXxZz";
 
-	t.same( output, expected );
-
-	t.end();
+	expect(output).toBe(expected);
 });
 
-tape('remove cyrillic accents from string', function(t) {
-	var input = 'ЁёЙй';
+test("remove cyrillic accents from string", function () {
+	var input = "ЁёЙй";
 	var output = removeAccents(input);
-	var expected = 'ЕеИи';
+	var expected = "ЕеИи";
 
-	t.same( output, expected );
-
-	t.end();
+	expect(output).toBe(expected);
 });
 
-tape('do not modify non-accented strings', function(t) {
-	var input = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz123456789.,:;~`!@#$%^&*()-_=+[]{}\'"|\\<>?/eEиИ';
+test("do not modify non-accented strings", function () {
+	var input =
+		"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz123456789.,:;~`!@#$%^&*()-_=+[]{}'\"|\\<>?/eEиИ";
 	var output = removeAccents(input);
 
-	t.same( output, input );
-
-	t.end();
+	expect(output).toBe(input);
 });
 
-tape('.has can detect accents', function(t) {
-	t.equal(removeAccents.has('À'), true);
-	t.equal(removeAccents.has('Löwe'), true);
+test(".has can detect accents", function () {
+	expect(removeAccents.has("À")).toBe(true);
+	expect(removeAccents.has("Löwe")).toBe(true);
 
-	t.equal(removeAccents.has('A'), false);
-	t.equal(removeAccents.has('Panther'), false);
-
-	t.end();
+	expect(removeAccents.has("A")).toBe(false);
+	expect(removeAccents.has("Panther")).toBe(false);
 });
 
-tape('.remove method', function(t) {
-	t.same(removeAccents.toString(), removeAccents.remove.toString());
+test(".remove method", function () {
+	expect(removeAccents.toString()).toBe(removeAccents.remove.toString());
 
-	t.same(removeAccents.remove('cat'), 'cat');
-	t.same(removeAccents.remove('Pokémon'), 'Pokemon');
-
-	t.end();
+	expect(removeAccents.remove("cat")).toBe("cat");
+	expect(removeAccents.remove("Pokémon")).toBe("Pokemon");
 });
 
 // See https://github.com/tyxla/remove-accents/issues/12
-tape('ß is not accented', function(t) {
-  t.same(removeAccents.remove('Straße'), 'Straße');
-  t.end();
+test("ß is not accented", function () {
+	expect(removeAccents.remove("Straße")).toBe("Straße");
 });


### PR DESCRIPTION
This PR replaces the testing framework from `tape` to `jest`, which is more modern and more flexible. I'm also doing some drive-by formatting fixes on the test file. Finally, we're bumping the minimum Node version to v14, since older versions are already dead for a while. 